### PR TITLE
Solution for issue#10. Hard reload user page after processing forms

### DIFF
--- a/attendance/views.py
+++ b/attendance/views.py
@@ -84,8 +84,7 @@ def user(request, username):
                     user = request.user,
                     datetime = timezone.now(),
             )
-        return HttpResponse("<script>location.assign(window.location);</script>")
-        # hard reload the page without any forms
+        return HttpResponseRedirect(""); # hard reload the page without any forms
     u = User.objects.get(username=username)
     s = Session.objects.get_sessions_this_month(user=u)
 

--- a/attendance/views.py
+++ b/attendance/views.py
@@ -84,6 +84,8 @@ def user(request, username):
                     user = request.user,
                     datetime = timezone.now(),
             )
+        return HttpResponse("<script>location.assign(window.location);</script>")
+        # hard reload the page without any forms
     u = User.objects.get(username=username)
     s = Session.objects.get_sessions_this_month(user=u)
 

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -96,6 +96,8 @@ class FunctionalTest(StaticLiveServerTestCase):
                 value=session_key,
                 path='/',
         ))
+    
+        
 
 class LoginLogoutTest(FunctionalTest):
     def test_login_and_logout_users(self):
@@ -308,6 +310,18 @@ class SessionTest(FunctionalTest):
             finally:
                 self.browser.get(self.server_url + "/logout/")
                 self.assertIn(self.server_url + "/login/",self.browser.current_url)
+                
+    def test_user_can_refresh_page_without_resending_forms(self):
+        user = UserFactory.create()
+        self.browser.get(self.server_url)
+
+        self.login_by_form(user.username,"password", self.browser)
+        self.browser.find_element_by_name('IN').click()
+        self.wait_for_element_with_id('myDropdown')
+        self.browser.refresh();
+        self.assertIn(self.server_url + "/user/",self.browser.current_url)
+        
+         
 
 class APITest(FunctionalTest):
     '''


### PR DESCRIPTION
Reload without resending forms causes that user can reload the page and is there no forms to resend. It's a little slower because page reloads twice after sending forms. 