### PR TITLE
Redirect if year or month is not specified in url of administration page

### DIFF
--- a/attendance/views.py
+++ b/attendance/views.py
@@ -389,7 +389,12 @@ def swipe_detail(request, username, id):
         return HttpResponse("Restricted to " + session.user.username)
 
 @login_required(login_url='/login/')
-def administrator(request, year=str(datetime.now().year), month="{0:02d}".format(datetime.now().month-1, '02d'), project=""):
+def administrator(request, year=None, month=None, project=""):
+    if year==None or month==None:
+        return HttpResponseRedirect(reverse(administrator, args=[
+                str(datetime.now().year),
+                str("{0:02d}".format(datetime.now().month-1, '02d')),
+        ]));
     if not (request.user.is_superuser or request.user.is_staff):
         return HttpResponse("Restricted to staff.")
     user_data, empty_users, projects_data = [], [], []


### PR DESCRIPTION
So year and month will always appear in url and causes errors no more

Signed-off-by: DavidKozina <david.kozina@volny.cz>