### PR TITLE
Use custom Password Reset Form For Known Email

### DIFF
--- a/attendance/forms.py
+++ b/attendance/forms.py
@@ -63,7 +63,6 @@ class SwipeEditForm(forms.ModelForm):
 
 class PasswordResetFormForKnownEmail(PasswordResetForm):
     def clean_email(self):
-        print("\n\nHello\n\n")
         data = self.cleaned_data["email"]
         try:
             User.objects.get(email=data)

--- a/attendance/forms.py
+++ b/attendance/forms.py
@@ -3,6 +3,8 @@ from .models import Session, ProjectSeparation, Swipe
 from django.contrib.admin.widgets import AdminDateWidget
 from datetimewidget.widgets import DateTimeWidget
 from datetime import timedelta
+from django.contrib.auth.forms import PasswordResetForm
+from django.contrib.auth.models import User
 
 class SessionForm(forms.ModelForm):
     class Meta:
@@ -57,3 +59,15 @@ class SwipeEditForm(forms.ModelForm):
                 raise forms.ValidationError("Conflict with next swipe " + str(next_swipe))
 
         return  data
+
+
+class PasswordResetFormForKnownEmail(PasswordResetForm):
+    def clean_email(self):
+        print("\n\nHello\n\n")
+        data = self.cleaned_data["email"]
+        try:
+            User.objects.get(email=data)
+        except User.DoesNotExist:
+            raise forms.ValidationError("Email does not belong to any user")
+
+        return data

--- a/ticker/urls.py
+++ b/ticker/urls.py
@@ -10,6 +10,7 @@ from django.contrib.auth.views import (
     password_reset_complete
 )
 from rest_framework import routers
+from attendance.forms import PasswordResetFormForKnownEmail
 
 swipes_router = routers.DefaultRouter()
 swipes_router.register(r'api/swipes', views.SwipeViewSet)
@@ -63,7 +64,8 @@ urlpatterns = [
     # password reset section
     url(r'^user/password/reset/$',
         password_reset,
-        {'post_reset_redirect': '/user/password/reset/done/'},
+        {'post_reset_redirect': '/user/password/reset/done/',
+        'password_reset_form': PasswordResetFormForKnownEmail},
         name="password_reset"),
 
     url(r'^user/password/reset/done/$', password_reset_done),


### PR DESCRIPTION
If user while reseting password type in email which is not in database it shows an error message instead of success message.